### PR TITLE
fix: grep stray "\" warning

### DIFF
--- a/bin/trackdown.sh
+++ b/bin/trackdown.sh
@@ -124,7 +124,7 @@ fi
 if [ "$CMD" = "issues" ] ; then
 
   discoverIssues
-  grep "^\#\#\ " $ISSUES | sed -e "s/^##\ /- /g"
+  grep "^##\s" $ISSUES | sed -e "s/^##\ /- /g"
 
 fi
 


### PR DESCRIPTION
Hey there @mgoellnitz,

I didn't find any other way to contact therefore here is a question posed as a
PR. On my setup I end up wit the following warnings from `grep`

```sh
$ ./trackdown.sh issues
TrackDown-git: base directory /<redacted>/<repo>
Remote system is <redacted> with project "<repo>" and user ~octvs
grep: warning: stray \ before #
grep: warning: stray \ before #
grep: warning: stray \ before white space
```

To eliviate this issue I did this minor change. But I still wanted to check
whether there is something I'm missing.

Cheers
